### PR TITLE
fixed empty string issue

### DIFF
--- a/client/components/allUsers.js
+++ b/client/components/allUsers.js
@@ -9,8 +9,7 @@ export class AllUsers extends Component {
   constructor(props){
     super(props);
     this.state = {
-      id: null,
-      isAdmin: '',
+      id: null
     }
     this.handleSelect = this.handleSelect.bind(this);
     this.handleEditClick = this.handleEditClick.bind(this);
@@ -115,10 +114,3 @@ const mapDispatch = function (dispatch) {
 }
 
 export default connect(mapState, mapDispatch)(AllUsers)
-
-// /**
-//  * PROP TYPES
-//  */
-// AllProducts.propTypes = {
-//   products: PropTypes.array
-// }


### PR DESCRIPTION
No longer tries to submit an empty string for `isAdmin` or `isActive`.